### PR TITLE
Data de expiração agora aceitando 2 ou 4 dígitos

### DIFF
--- a/rede-woocommerce/CHANGELOG.md
+++ b/rede-woocommerce/CHANGELOG.md
@@ -1,0 +1,21 @@
+Project: Rede WooCommerce
+Description: Rede API integration for WooCommerce.
+Version: 1.2.2
+Author(s): Rede
+URL: https://github.com/DevelopersRede/woocommerce
+Keywords: rede, e-rede, redecard, woocommerce
+
+All notable changes to this project will be documented in this file.
+This project adheres to [Semantic Versioning](http://semver.org/)
+
+## Unreleased
+
+### Changed:
+
+- Card expiry date now accepts 2 digit year as well.
+- Added more information to plugin header:
+- Added CHANGELOG.md and README.txt files
+
+## [2019-10-13] - 1.2.2
+
+Número de versão no plugin atualizada de 1.0.0 para 1.2.2 para coincidir com os números de versões dos releases no repositório oficial da REDE ( https://github.com/DevelopersRede/woocommerce )

--- a/rede-woocommerce/README.txt
+++ b/rede-woocommerce/README.txt
@@ -1,0 +1,30 @@
+=== Rede WooCommerce ===
+Tags: rede, e-rede, redecard, woocommerce
+Requires at least: 5.0
+Tested up to: 5.2
+Requires PHP: 7.1
+Stable tag: 1.2.2
+License: MIT
+License URI: https://opensource.org/licenses/MIT
+
+Rede API integration for WooCommerce
+
+== Description ==
+Rede API integration for WooCommerce
+
+== Installation ==
+Faça download da última release em https://github.com/DevelopersRede/woocommerce/releases e copie o diretório rede-woocommerce para  a pasta plugins de sua instalação do WordPress.
+
+== Changelog ==
+
+=== Unreleased ===
+
+### Alterações:
+
+- Data de expiração agora aceita 2 dígitos para ano também
+- Adicionado mais informações ao cabeçalho do plugin WordPress
+- Adicionados arquivos CHANGELOG.md e README.txt
+
+===  1.2.2 ===
+
+Número de versão no plugin atualizada de 1.0.0 para 1.2.2 para coincidir com os números de versões dos releases no repositório oficial da REDE ( https://github.com/DevelopersRede/woocommerce )

--- a/rede-woocommerce/includes/class-wc-rede-abstract.php
+++ b/rede-woocommerce/includes/class-wc-rede-abstract.php
@@ -222,7 +222,11 @@ abstract class WC_Rede_Abstract extends WC_Payment_Gateway
 
     protected function validate_installments($posted, $order_total)
     {
-        if (!isset($posted['rede_credit_installments']) && 1 == $this->installments) {
+        if (!isset($posted['rede_credit_installments'])) {
+            $posted['rede_credit_installments'] = 1;
+        }
+
+        if ($posted['rede_credit_installments'] == 1) {
             return true;
         }
 
@@ -235,7 +239,7 @@ abstract class WC_Rede_Abstract extends WC_Payment_Gateway
             $min_value = $this->get_option('min_parcels_value');
             $max_parcels = $this->get_option('max_parcels_number');
 
-            if ($installments > $max_parcels || ($min_value != 0 && $order_total / $installments < $min_value)) {
+            if ($installments > $max_parcels || (($min_value != 0) && (($order_total / $installments) < $min_value))) {
                 throw new Exception('Número inválido de parcelas');
             }
         } catch (Exception $e) {

--- a/rede-woocommerce/includes/class-wc-rede-credit.php
+++ b/rede-woocommerce/includes/class-wc-rede-credit.php
@@ -33,6 +33,9 @@ class WC_Rede_Credit extends WC_Rede_Abstract
         $this->max_parcels_number = $this->get_option('max_parcels_number');
         $this->min_parcels_value = $this->get_option('min_parcels_value');
 
+        $this->partner_module = $this->get_option('module');
+        $this->partner_gateway = $this->get_option('gateway');
+
         $this->debug = $this->get_option('debug');
 
         if ('yes' == $this->debug) {
@@ -260,6 +263,27 @@ class WC_Rede_Credit extends WC_Rede_Abstract
                     '12' => '12x'
                 )
             ),
+
+            'partners' => array(
+                'title' => 'Configuracões para parceiros',
+                'type' => 'title'
+            ),
+            'module' => array(
+                'title' => 'ID Módulo',
+                'type' => 'text',
+                'default' => ''
+            ),
+            'gateway' => array(
+                'title' => 'ID Gateway',
+                'type' => 'text',
+                'default' => ''
+            ),
+
+            'developers' => array(
+                'title' => 'Configuracões para desenvolvedores',
+                'type' => 'title'
+            ),
+
             'debug' => array(
                 'title' => 'Depuração',
                 'type' => 'checkbox',
@@ -294,17 +318,17 @@ class WC_Rede_Credit extends WC_Rede_Abstract
             $label = sprintf('%dx de R$ %.02f', $i, $order_total / $i);
 
             if ($i == 1) {
-                sprintf('R$ %.02f à vista', $order_total);
-            }
-
-            if ($order_total / $i < $min_value) {
-                break;
+                $label = sprintf('R$ %.02f à vista', $order_total);
             }
 
             $installments[] = array(
                 'num' => $i,
                 'label' => $label
             );
+
+            if (($order_total / $i) < $min_value) {
+                break;
+            }
         }
 
         if (count($installments) == 0) {

--- a/rede-woocommerce/rede-woocommerce.php
+++ b/rede-woocommerce/rede-woocommerce.php
@@ -2,6 +2,7 @@
 /**
  * Plugin Name: Rede WooCommerce
  * Plugin URI:        https://github.com/DevelopersRede/woocommerce
+ * GitHub Plugin URI: https://github.com/celsobessa/rede-woocommerce
  * Description: Rede API integration for WooCommerce
  * Version:     1.2.2
  * Requires PHP:      7.1

--- a/rede-woocommerce/rede-woocommerce.php
+++ b/rede-woocommerce/rede-woocommerce.php
@@ -3,8 +3,13 @@
  * Plugin Name: Rede WooCommerce
  * Plugin URI:        https://github.com/DevelopersRede/woocommerce
  * Description: Rede API integration for WooCommerce
- * Author:      Rede
  * Version:     1.2.2
+ * Requires PHP:      7.1
+ * Requires at least: 5.0
+ * Author:      Rede
+ * Author URI:        https://github.com/DevelopersRede/
+ * License:           MIT
+ * License URI:       https://opensource.org/licenses/MIT
  * Text Domain: rede-woocommerce
  *
  * @package WC_Rede

--- a/rede-woocommerce/templates/credit-card/rede-payment-form.php
+++ b/rede-woocommerce/templates/credit-card/rede-payment-form.php
@@ -16,9 +16,9 @@ if (!defined('ABSPATH')) {
                                                              style="font-size: 1.5em; padding: 8px;"/>
     </p>
 
-    <?php if (!empty($installments)) : ?>
+    <?php if (is_array($installments) && count($installments) > 1) : ?>
         <p class="form-row form-row-wide">
-            <label for="installments">Parcelas<span
+            <label for="installments">Parcelas <?= count($installments) ?><span
                         class="required">*</span></label> <select id="installments"
                                                                   name="rede_credit_installments">
                 <?php


### PR DESCRIPTION
- Data de expiração agora aceita 2 dígitos para ano também
- Adicionado mais informações ao cabeçalho do plugin WordPress
- Adicionados arquivos CHANGELOG.md e README.txt

Resolve os incidentes 8 e parte do 11 (ano com dois dígitos)

Close #8 and part of #11 