### PR TITLE
Ajustes versão suportada WC 4.8.0

### DIFF
--- a/rede-woocommerce.php
+++ b/rede-woocommerce.php
@@ -7,10 +7,10 @@
  * Author URI:  https://www.userede.com.br/
  * Version:     2.1.2
  * Requires at least: 5.5
- * Tested up to: 5.5.3
+ * Tested up to: 5.6.0
  * Requires PHP: 7.2
  * WC requires at least: 3.0.0
- * WC tested up to: 4.7.0
+ * WC tested up to: 4.8.0
  * Text Domain: rede-woocommerce
  *
  * @package WC_Rede

--- a/rede-woocommerce.php
+++ b/rede-woocommerce.php
@@ -6,10 +6,12 @@
  * Author:      Rede
  * Author URI:  https://www.userede.com.br/
  * Version:     2.1.2
- * Tested up to: 4.6.2
- * Text Domain: rede-woocommerce
  * Requires at least: 5.5
+ * Tested up to: 5.5.3
  * Requires PHP: 7.2
+ * WC requires at least: 3.0.0
+ * WC tested up to: 4.7.0
+ * Text Domain: rede-woocommerce
  *
  * @package WC_Rede
  */


### PR DESCRIPTION
O WooCommerce possui uma flag específica para identificar a versão testada:
"WC tested up to"

Precisaria apenas testar com relação a versão mínima do WordPress, para não impedir um futuro aviso de atualização do plugin, caso o usuário esteja executando uma versão menor:
 * Requires at least: 5.5

Por fim, embora o WordPress ignore, no repositório de plugins, informação sobre versões menores (minor update), incluindo automaticamente esse valor, como este repositório não está publicado lá mantive aqui, já incluindo a versão mais recente do WooCommerce:
 * Tested up to: 5.6.0
 * WC tested up to: 4.8.0

https://developer.wordpress.org/plugins/wordpress-org/how-your-readme-txt-works/